### PR TITLE
safety checks for getStats

### DIFF
--- a/lib/kafka/Drainer.js
+++ b/lib/kafka/Drainer.js
@@ -77,7 +77,7 @@ class Drainer {
 
             queueSize: this._q ? this._q.length() : null,
 
-            isPaused: this.isPaused(),
+            isPaused: this.consumer && this.consumer.isConsumer ? this.isPaused() : null,
 
             drainStats: this._stats
         };

--- a/lib/kafka/PartitionDrainer.js
+++ b/lib/kafka/PartitionDrainer.js
@@ -205,7 +205,7 @@ class PartitionDrainer {
 
             receivedFirstMsg: this._receivedFirst,
 
-            isPaused: this.isPaused(),
+            isPaused: this.consumer && this.consumer.isConsumer ? this.isPaused() : null,
 
             drainStats: this._stats,
             partitions: this._queueMap ? Object.keys(this._queueMap).length : null,

--- a/lib/kafka/Publisher.js
+++ b/lib/kafka/Publisher.js
@@ -56,7 +56,7 @@ class Publisher {
         return {
             totalPublished: this._totalSentMessages,
             last: this._lastProcessed,
-            isPaused: this.isPaused()
+            isPaused: this.producer && this.producer.isProducer ? this.isPaused() : null
         };
     }
 


### PR DESCRIPTION
adds consumer safety checks to prevent exception if consumer/producer
is not yet initialized or closed, but stats are requested