### PR TITLE
Propagate connect event from consumer not client

### DIFF
--- a/lib/kafka/Kafka.js
+++ b/lib/kafka/Kafka.js
@@ -45,7 +45,6 @@ class Kafka extends EventEmitter {
     this.targetTopics = [];
 
     this._logger = logger;
-    this._connectFired = false;
     this._producerReadyFired = false;
   }
 
@@ -277,15 +276,10 @@ class Kafka extends EventEmitter {
 
   _attachConsumerListeners(dontListenForSIGINT = false, commitOnSIGINT = false){
 
-    this.client.on("connect", () => {
-
-      //not sure why, but kafka-node seems to emit this twice
-      if(!this._connectFired){
-        this._connectFired = true;
-        this._getLogger().info("consumer is connected / ready.");
-        this.emit("connect");
-        this.emit("ready");
-      }
+    this.consumer.once("connect", () => {
+      this._getLogger().info("consumer is connected / ready.");
+      this.emit("connect");
+      this.emit("ready");
     });
 
     //do not listen for "message" here
@@ -316,7 +310,6 @@ class Kafka extends EventEmitter {
     this.isConsumer = false;
     this.client = null;
     this.consumer = null;
-    this._connectFired = false;
   }
 
   _resetProducer(){


### PR DESCRIPTION
Client `connect` events don't imply a successful consumer connection (only that the client socket has connected) which means the connect promise might resolve before the consumer is successfully connected.  Also, client `connect` events might fire multiple times during one call to connect.

Details:

The client emits `connect` whenever the socket connects (https://github.com/SOHU-Co/kafka-node/blob/52f38b5af61ce254a16d41996f3a41b5e344c593/lib/kafkaClient.js#L492).  If a recoverable error occurs during connection (https://github.com/SOHU-Co/kafka-node/blob/52f38b5af61ce254a16d41996f3a41b5e344c593/lib/consumerGroup.js#L475), a reconnect may be scheduled (https://github.com/SOHU-Co/kafka-node/blob/52f38b5af61ce254a16d41996f3a41b5e344c593/lib/consumerGroupRecovery.js#L64) which can trigger further `connect` events on the client.  The successful `connect` event actually occurs later, on the consumer (https://github.com/SOHU-Co/kafka-node/blob/52f38b5af61ce254a16d41996f3a41b5e344c593/lib/consumerGroup.js#L487), after any retries.