### PR TITLE
Change delivery-report loglevel to debug

### DIFF
--- a/lib/librdkafka/NProducer.js
+++ b/lib/librdkafka/NProducer.js
@@ -127,7 +127,7 @@ class NProducer extends EventEmitter {
       });
 
       this.producer.on("delivery-report", (error, report) => {
-        logger.info("DeliveryReport: " + JSON.stringify(report));
+        logger.debug("DeliveryReport: " + JSON.stringify(report));
       });
 
       this.producer.on("disconnected", () => {


### PR DESCRIPTION
Change delivery-report loglevel from info to debug, because it produces a log for every produced message.