### PR TITLE
Allow to commit a specific message, instead of all pending messages

### DIFF
--- a/lib/librdkafka/NConsumer.js
+++ b/lib/librdkafka/NConsumer.js
@@ -659,6 +659,31 @@ class NConsumer extends EventEmitter {
   }
 
   /**
+   * commit given message
+   * @param {Boolean} async - optional, if commit should be async (default is false)
+   * @param {{topic, partition, offset}} message
+   * @returns {boolean}
+   */
+  commitMessage(async = false, message) {
+    if(!this.consumer){
+      return false;
+    }
+
+    if(async){
+      this.consumer.commitMessage(message);
+      return true;
+    }
+
+    try {
+      this.consumer.commitMessageSync(message);
+      return true;
+    } catch(error){
+      super.emit("error", error);
+      return false;
+    }
+  }
+
+  /**
    * @deprecated
    */
   consumeOnce() {


### PR DESCRIPTION
In our application it can happen that we consume a new message, although the previouse is not fully processed. For that to handle we need to be able to commit the highest offset of alle processed messages != all consumed message. I implemented a simple wrapper around node-rdkafka's `commitMessage` method