### PR TITLE
same partitioner-key logic for all produce methods (NProducer)

### DIFF
--- a/lib/librdkafka/NProducer.js
+++ b/lib/librdkafka/NProducer.js
@@ -282,9 +282,10 @@ class NProducer extends EventEmitter {
    * @param {object} message - value object for the message
    * @param {number} _partition - optional partition to produce to
    * @param {string} _key - optional message key
+   * @param {string} _partitionKey - optional key to evaluate partition for this message
    * @returns {Promise.<object>}
    */
-  async send(topicName, message, _partition = null, _key = null) {
+  async send(topicName, message, _partition = null, _key = null, _partitionKey = null) {
 
     if (!this.producer) {
       throw new Error("You must call and await .connect() before trying to produce messages.");
@@ -297,6 +298,9 @@ class NProducer extends EventEmitter {
     if (!message || !(typeof message === "string" || Buffer.isBuffer(message))) {
       throw new Error("message must be a string or an instance of Buffer.");
     }
+
+    const key = _key ? _key : uuid.v4();
+    message = Buffer.isBuffer(message) ? message : new Buffer(message);
 
     let maxPartitions = 0;
     //find correct max partition count
@@ -311,16 +315,13 @@ class NProducer extends EventEmitter {
     }
 
     let partition = 0;
-    //find correct partition count
+    //find correct partition for this key
     if (maxPartitions >= 2 && typeof _partition !== "number") { //manual check to improve performance
-      partition = NProducer._getRandomIntInclusive(0, maxPartitions - 1);
+      partition = this._getPartitionForKey(_partitionKey ? _partitionKey : key, maxPartitions);
     }
 
     //if _partition (manual) is set, it always overwrites a selected partition
     partition = typeof _partition === "number" ? _partition : partition;
-
-    const key = _key ? _key : uuid.v4();
-    message = Buffer.isBuffer(message) ? message : new Buffer(message);
 
     this.config.logger.debug(JSON.stringify({
       topicName,
@@ -348,9 +349,10 @@ class NProducer extends EventEmitter {
    * @param {object} payload - object (part of message value)
    * @param {number} partition - optional partition to produce to
    * @param {number} version - optional version of the message value
+   * @param {string} partitionKey - optional key to evaluate partition for this message
    * @returns {Promise.<object>}
    */
-  async buffer(topic, identifier, payload, partition = null, version = null) {
+  async buffer(topic, identifier, payload, partition = null, version = null, partitionKey = null) {
 
     if (typeof identifier === "undefined") {
       identifier = uuid.v4();
@@ -372,22 +374,7 @@ class NProducer extends EventEmitter {
       payload.version = version;
     }
 
-    if (typeof partition !== "number") {
-
-      let maxPartitions = this.defaultPartitionCount;
-
-      if (maxPartitions === "auto") {
-        maxPartitions = await this.getPartitionCountOfTopic(topic);
-        if (maxPartitions === -1) {
-          throw new Error("defaultPartition set to 'auto', but was not able to resolve partition count for topic" +
-            topic + ", please make sure the topic exists before starting the producer in auto mode.");
-        }
-      }
-
-      partition = this._getPartitionForKey(identifier, maxPartitions);
-    }
-
-    return await this.send(topic, JSON.stringify(payload), partition, identifier);
+    return await this.send(topic, JSON.stringify(payload), partition, identifier, partitionKey);
   }
 
   /**
@@ -434,23 +421,7 @@ class NProducer extends EventEmitter {
       type: topic + messageType
     };
 
-    if (typeof partition !== "number") {
-
-      const key = partitionKey ? partitionKey : identifier;
-      let maxPartitions = this.defaultPartitionCount;
-
-      if (maxPartitions === "auto") {
-        maxPartitions = await this.getPartitionCountOfTopic(topic);
-        if (maxPartitions === -1) {
-          throw new Error("defaultPartition set to 'auto', but was not able to resolve partition count for topic" +
-            topic + ", please make sure the topic exists before starting the producer in auto mode.");
-        }
-      }
-
-      partition = this._getPartitionForKey(key, maxPartitions);
-    }
-
-    return await this.send(topic, JSON.stringify(payload), partition, identifier);
+    return await this.send(topic, JSON.stringify(payload), partition, identifier, partitionKey);
   }
 
   /**
@@ -655,20 +626,6 @@ class NProducer extends EventEmitter {
       this.producer.disconnect();
       //this.producer = null;
     }
-  }
-
-  /**
-   * @static
-   * @private
-   * returns random number in range
-   * @param {number} min
-   * @param {number} max
-   * @returns {number}
-   */
-  static _getRandomIntInclusive(min, max) {
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
   /**


### PR DESCRIPTION
remove simple random number partition chooser for send()
based all produce action on the same partionKey logic