### PR TITLE
Re-implemented murmur2 partitioner, to be consistent with Kafka Java client

### DIFF
--- a/lib/librdkafka/NProducer.js
+++ b/lib/librdkafka/NProducer.js
@@ -5,6 +5,7 @@ const Promise = require("bluebird");
 const uuid = require("uuid");
 const murmur = require("murmurhash");
 const debug = require("debug");
+const murmur2Partitioner = require("murmur2-partitioner");
 
 const Metadata = require("./Metadata.js");
 const {
@@ -101,19 +102,6 @@ class NProducer extends EventEmitter {
 
     this._murmurHashVersion = this.config.options.murmurHashVersion || DEFAULT_MURMURHASH_VERSION;
     this.config.logger.info(`using murmur ${this._murmurHashVersion} partitioner.`);
-    switch (this._murmurHashVersion) {
-
-    case "2":
-      this._murmur = murmur.v2;
-      break;
-
-    case "3":
-      this._murmur = murmur.v3;
-      break;
-
-    default:
-      throw new Error(`${this._murmurHashVersion} is not a supported murmur hash version. Choose '2' or '3'.`);
-    }
 
     this._errors = 0;
     super.on("error", () => this._errors++);
@@ -263,7 +251,6 @@ class NProducer extends EventEmitter {
    * @returns {string} - deterministic partition value for key
    */
   _getPartitionForKey(key, partitionCount = 1) {
-
     if (typeof key !== "string") {
       throw new Error("key must be a string.");
     }
@@ -272,7 +259,16 @@ class NProducer extends EventEmitter {
       throw new Error("partitionCount must be number.");
     }
 
-    return this._murmur(key) % partitionCount;
+    switch (this._murmurHashVersion) {
+    case "2":
+      return murmur2Partitioner.partition(key, partitionCount);
+        
+    case "3":
+      return murmur.v3(key) % partitionCount;
+        
+    default:
+      throw new Error(`${this._murmurHashVersion} is not a supported murmur hash version. Choose '2' or '3'.`);
+    }
   }
 
   /**

--- a/lib/librdkafka/NProducer.js
+++ b/lib/librdkafka/NProducer.js
@@ -103,6 +103,19 @@ class NProducer extends EventEmitter {
     this._murmurHashVersion = this.config.options.murmurHashVersion || DEFAULT_MURMURHASH_VERSION;
     this.config.logger.info(`using murmur ${this._murmurHashVersion} partitioner.`);
 
+    switch (this._murmurHashVersion) {
+    case "2":
+      this._murmur = (key, partitionCount) => murmur2Partitioner.partition(key, partitionCount);
+      break;
+          
+    case "3":
+      this._murmur = (key, partitionCount) => murmur.v3(key) % partitionCount;
+      break;
+          
+    default:
+      throw new Error(`${this._murmurHashVersion} is not a supported murmur hash version. Choose '2' or '3'.`);
+    }
+
     this._errors = 0;
     super.on("error", () => this._errors++);
   }
@@ -259,16 +272,7 @@ class NProducer extends EventEmitter {
       throw new Error("partitionCount must be number.");
     }
 
-    switch (this._murmurHashVersion) {
-    case "2":
-      return murmur2Partitioner.partition(key, partitionCount);
-        
-    case "3":
-      return murmur.v3(key) % partitionCount;
-        
-    default:
-      throw new Error(`${this._murmurHashVersion} is not a supported murmur hash version. Choose '2' or '3'.`);
-    }
+    this._murmur(key, partitionCount);
   }
 
   /**


### PR DESCRIPTION
Using https://github.com/vuza/murmur2-partitioner for murmur2 partitioning, which is tested to be consistent with Kafka's Java client. Also fixing this two issues: https://github.com/nodefluent/node-sinek/issues/40, https://github.com/nodefluent/node-sinek/issues/39