### PR TITLE
Start analytics immediately

### DIFF
--- a/lib/librdkafka/NConsumer.js
+++ b/lib/librdkafka/NConsumer.js
@@ -111,6 +111,7 @@ class NConsumer extends EventEmitter {
    * @throws
    * starts analytics tasks
    * @param {object} options - analytic options
+   * @returns {Promise} resolves after as soon as analytics are available
    */
   enableAnalytics(options = {}){
 

--- a/lib/librdkafka/NConsumer.js
+++ b/lib/librdkafka/NConsumer.js
@@ -129,6 +129,10 @@ class NConsumer extends EventEmitter {
 
     this._analyticsIntv = setInterval(this._runAnalytics.bind(this), analyticsInterval);
     this._lagCheckIntv = setInterval(this._runLagCheck.bind(this), lagFetchInterval);
+
+    // Make analytics available immediately
+    return this._runAnalytics()
+      .then(() => this._runLagCheck());
   }
 
   /**
@@ -978,7 +982,7 @@ class NConsumer extends EventEmitter {
       this._analytics = new ConsumerAnalytics(this, this._analyticsOptions || {}, this.config.logger);
     }
 
-    this._analytics.run()
+    return this._analytics.run()
       .then(res => super.emit("analytics", res))
       .catch(error => super.emit("error", error));
   }
@@ -1003,7 +1007,7 @@ class NConsumer extends EventEmitter {
    * @private
    */
   _runLagCheck(){
-    this.getLagStatus(true).catch(() => {});
+    return this.getLagStatus(true).catch(() => {});
   }
 
   /**


### PR DESCRIPTION
Currently when NConsumer's `enableAnalytics` is called you have to wait until (1st) `_runAnalytics` gets called the first time after a given timeout and (2nd) `_analytics.run()` resolves, which takes an unknown amount of time.
This little PR changes that behaviour in order to make health available immediately after `enableAnalytics` resolves.