### PR TITLE
Give user chance to set message correlation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ATTENTION: This is a fork
+
+The CRM team forked [nodefluent/node-sinek](https://github.com/nodefluent/node-sinek). Find new features at branch `correlation-id`. We are going to create a PR to the original repository with this feature branch.
+
 # High Level Node.js Kafka Client - sinek
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/nodefluent/node-sinek.svg)](https://greenkeeper.io/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# ATTENTION: This is a fork
-
-The CRM team forked [nodefluent/node-sinek](https://github.com/nodefluent/node-sinek). Find new features at branch `correlation-id`. We are going to create a PR to the original repository with this feature branch.
-
 # High Level Node.js Kafka Client - sinek
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/nodefluent/node-sinek.svg)](https://greenkeeper.io/)

--- a/lib/librdkafka/NProducer.js
+++ b/lib/librdkafka/NProducer.js
@@ -107,11 +107,11 @@ class NProducer extends EventEmitter {
     case "2":
       this._murmur = (key, partitionCount) => murmur2Partitioner.partition(key, partitionCount);
       break;
-          
+
     case "3":
       this._murmur = (key, partitionCount) => murmur.v3(key) % partitionCount;
       break;
-          
+
     default:
       throw new Error(`${this._murmurHashVersion} is not a supported murmur hash version. Choose '2' or '3'.`);
     }
@@ -283,9 +283,10 @@ class NProducer extends EventEmitter {
    * @param {number} _partition - optional partition to produce to
    * @param {string} _key - optional message key
    * @param {string} _partitionKey - optional key to evaluate partition for this message
+   * @param {*} _opaqueKey - optional opaque token, which gets passed along to your delivery reports
    * @returns {Promise.<object>}
    */
-  async send(topicName, message, _partition = null, _key = null, _partitionKey = null) {
+  async send(topicName, message, _partition = null, _key = null, _partitionKey = null, _opaqueKey = null) {
 
     if (!this.producer) {
       throw new Error("You must call and await .connect() before trying to produce messages.");
@@ -333,7 +334,7 @@ class NProducer extends EventEmitter {
     this._lastProcessed = producedAt;
     this._totalSentMessages++;
 
-    this.producer.produce(topicName, partition, message, key, producedAt);
+    this.producer.produce(topicName, partition, message, key, producedAt, _opaqueKey);
 
     return {
       key,


### PR DESCRIPTION
When producing a message through librdkafka you can set an opaque correlation id which gets added to the delivery report. This is useful if you want to correlate produced messages to their produce result. In order to use this feature, the user of node-sinek has to be able to set the correlation id by himself.