### PR TITLE
use 'buffer' for default JS Kafka encoding

### DIFF
--- a/lib/kafka/Kafka.js
+++ b/lib/kafka/Kafka.js
@@ -180,7 +180,9 @@ class Kafka extends EventEmitter {
       fetchMaxWaitMs: 100,
       autoCommit: autoCommit,
       autoCommitIntervalMs: 5000,
-      connectRetryOptions: this.connectDirectlyToBroker ? DEFAULT_RETRY_OPTIONS : undefined
+      connectRetryOptions: this.connectDirectlyToBroker ? DEFAULT_RETRY_OPTIONS : undefined,
+      encoding: "buffer",
+      keyEncoding: "buffer"
     };
 
     //overwrite default options


### PR DESCRIPTION
this makes the messages consumed by the JS Kafka Client match the
native librdkafka backend and create buffers for the key and value

this also makes the JS Kafka client match the documentation.