### PR TITLE
Add "auto" as value for defaultPartitionCount in NProducer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,7 @@ declare module "sinek" {
     }
 
     export class NProducer {
-        constructor(config: IKafka, _?: null, defaultPartitionCount?: number)
+        constructor(config: IKafka, _?: null, defaultPartitionCount?: number | "auto")
         on(eventName: "error", callback: (error: any) => any): void;
         on(eventName: "ready", callback: () => any): void;
         connect(): Promise<void>;


### PR DESCRIPTION
According to [this line](https://github.com/nodefluent/node-sinek/blob/master/lib/librdkafka/NProducer.js#L311) the defaultPartitionCount of NProducer could also be of value "auto".