### PR TITLE
Add option for delivery-callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ declare module "sinek" {
         "coordinator.query.interval.ms"?: number;
         "group.id"?: string;
         "event_cb"?: boolean;
+        "dr_cb"?: boolean;
     }
 
     export interface NConsumerKafkaOptions extends NCommonKafkaOptions {


### PR DESCRIPTION
The `dr_cb` option was missing in the type definition...