### PR TITLE
Fix Travis build, point to new release version of kafka

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - mocha --exit --timeout 60000 -R spec test/int/*
 
 before_install:
-- wget http://www.us.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz -O kafka.tgz
+- wget http://www.us.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz -O kafka.tgz
 - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
 - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
 - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"


### PR DESCRIPTION
Point to new version of kafka, previous version has moved to http://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz