### PR TITLE
Fix CI: update kafka download link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,24 @@ node_js:
   - "node"
 env:
   global:
-  - ZOOKEEPER_PEERS=localhost:2181
-  - KAFKA_PEERS=localhost:9092
-  - KST_TOPIC=travis
-  - CXX=g++-4.8
+    - ZOOKEEPER_PEERS=localhost:2181
+    - KAFKA_PEERS=localhost:9092
+    - KST_TOPIC=travis
+    - CXX=g++-4.8
 
 script:
   - npm run lint
   - mocha --exit --timeout 60000 -R spec test/int/*
 
 before_install:
-- wget http://www.us.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz -O kafka.tgz
-- mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
-- nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
-- nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
-- sleep 5
-- kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic sinek-test-topic-travis --zookeeper localhost:2181
-- kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic n-test-topic --zookeeper localhost:2181
-- sleep 2
+  - wget https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz -O kafka.tgz
+  - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
+  - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
+  - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
+  - sleep 5
+  - kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic sinek-test-topic-travis --zookeeper localhost:2181
+  - kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic n-test-topic --zookeeper localhost:2181
+  - sleep 2
 
 addons:
   apt:


### PR DESCRIPTION
The kafka download mirror was moved to https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz