### PR TITLE
fix typings for NConsumer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -231,7 +231,7 @@ declare module "sinek" {
     }
 
     export class NConsumer {
-        constructor(topic: Array<string>, config: KafkaConsumerConfig);
+        constructor(topic: Array<string> | string, config: KafkaConsumerConfig);
         on(eventName: "message", callback: (message: KafkaMessage) => any): void;
         on(eventName: "error", callback: (error: any) => any): void;
         on(eventName: "ready", callback: () => any): void;


### PR DESCRIPTION
This PR will add missing type `string`.

See `lib/librdkafka/NConsumer.js`:

```js
/**
 * creates a new consumer instance
 * @param {string|Array} topics - topic or topics to subscribe to
 * @param {object} config - configuration object
 */
constructor(topics, config = { options: {}, health: {} }) {
  [...]
  this.topics = Array.isArray(topics) ? topics : [topics];
  [...]
}
```