### PR TITLE
Added deploy github action to push to NPM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Create npm package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
* When a new release is created via github this action then publishes to NPM.
* Releases would work on tags
@krystianity would you be able to either:
a. Add a token to this repo under `NPM_TOKEN` so it can auto deploy to NPM
b. Add myself or @wtrocki to the NPM org so we can add a token to this repo to deploy